### PR TITLE
Add regex patterns for control characters and punctuation

### DIFF
--- a/pydantify/utility/patterns.py
+++ b/pydantify/utility/patterns.py
@@ -10,6 +10,10 @@ translation_map = {
     r"\P{N}": r"\D",  # All Numbers
     r"\p{Nd}": r"\d",  # decimal digit
     r"\P{Nd}": r"\D",  # decimal digit
+    r"\p{C}": r"[\x00-\x1F\x7F-\x9F]",  # invisible control characters and unused code points
+    r"\P{C}": r"[^\x00-\x1F\x7F-\x9F]",  # invisible control characters and unused code points
+    r"\p{P}": r"[!\"'#$%&\"()*+,\-./:;<=>?@[\\\]^_`{|}~]",  # punctuation
+    r"\P{P}": r"[^!\"'#$%&\"()*+,\-./:;<=>?@[\\\]^_`{|}~]",  # punctuation
 }
 
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -36,6 +36,26 @@ from pydantify.utility.patterns import convert_pattern
             r"\D\D",
             id="no numbers",
         ),
+        param(
+            r"\p{C}",
+            r"[\x00-\x1F\x7F-\x9F]",
+            id="control characters",
+        ),
+        param(
+            r"\P{C}",
+            r"[^\x00-\x1F\x7F-\x9F]",
+            id="no control characters",
+        ),
+        param(
+            r"\p{P}",
+            r"[!\"'#$%&\"()*+,\-./:;<=>?@[\\\]^_`{|}~]",
+            id="punctuation",
+        ),
+        param(
+            r"\P{P}",
+            r"[^!\"'#$%&\"()*+,\-./:;<=>?@[\\\]^_`{|}~]",
+            id="no punctuation",
+        ),
     ],
 )
 def test_pattern(input: str, expected: str):


### PR DESCRIPTION
## Summary: 
This PR adds new regex patterns for control characters and punctuation to the  `utility.patterns.convert_patterns` method and updates the corresponding tests. Without these, and the patch for `Decimal64` in https://github.com/pydantify/pydantify/issues/30, the  [nokia/7x50_YangModels](https://github.com/nokia/7x50_YangModels) models failed to build. They are now build capable.

## Changes:

### Utility Patterns:

- Added regex pattern for control characters (`\p{C}`) and its negation (`\P{C}`).
- Added regex pattern for punctuation (`\p{P}`) and its negation (`\P{P}`).

### Tests:

- Updated `test_patterns.py` to include new test cases for the added regex patterns.

