### PR TITLE
Add bits support

### DIFF
--- a/pydantify/models/typeresolver.py
+++ b/pydantify/models/typeresolver.py
@@ -190,6 +190,10 @@ class TypeResolver:
             case UnionTypeSpec.__qualname__:
                 union = tuple([cls.__resolve_type_statement(typ) for typ in spec.types])
                 return Union[union]  # type: ignore
+            case BitTypeSpec.__qualname__:
+                # Crafting a pattern like: ^(flag1|flag2|flag3|\s)*$
+                pattern = "^(" + "|".join([b[0] for b in spec.bits]) + "|\\s)*$"
+                return constr(pattern=pattern)
         assert False, f'Spec "{spec.__class__.__qualname__}" not yet implemented.'
 
     @classmethod

--- a/tests/examples/with_bits/expected.py
+++ b/tests/examples/with_bits/expected.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+from typing_extensions import Annotated
+
+
+class InterfacesContainer(BaseModel):
+    """
+    Just a simple example of a container.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        regex_engine="python-re",
+    )
+    name: Annotated[str, Field(alias="interfaces:name", title="NameLeaf")]
+    """
+    Interface name. Example value: GigabitEthernet 0/0/0
+    """
+    mybits: Annotated[
+        Optional[str],
+        Field(
+            alias="interfaces:mybits",
+            pattern="^(disable-nagle|auto-sense-speed|ten-mb-only|\\s)*$",
+            title="MybitsLeaf",
+        ),
+    ] = None
+
+
+class Model(BaseModel):
+    """
+    Initialize an instance of this class and serialize it to JSON; this results in a RESTCONF payload.
+
+    ## Tips
+    Initialization:
+    - all values have to be set via keyword arguments
+    - if a class contains only a `root` field, it can be initialized as follows:
+        - `member=MyNode(root=<value>)`
+        - `member=<value>`
+
+    Serialziation:
+    - `exclude_defaults=True` omits fields set to their default value (recommended)
+    - `by_alias=True` ensures qualified names are used (necessary)
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        regex_engine="python-re",
+    )
+    interfaces: Annotated[
+        Optional[InterfacesContainer], Field(alias="interfaces:interfaces")
+    ] = None
+
+
+if __name__ == "__main__":
+    model = Model(
+        # <Initialize model here>
+    )
+
+    restconf_payload = model.model_dump_json(
+        exclude_defaults=True, by_alias=True, indent=2
+    )
+
+    print(f"Generated output: {restconf_payload}")
+
+    # Send config to network device:
+    # from pydantify.utility import restconf_patch_request
+    # restconf_patch_request(url='...', user_pw_auth=('usr', 'pw'), data=restconf_payload)

--- a/tests/examples/with_bits/interfaces.yang
+++ b/tests/examples/with_bits/interfaces.yang
@@ -1,0 +1,37 @@
+module interfaces {
+  namespace
+  "http://ultraconfig.com.au/ns/yang/ultraconfig-interfaces";
+
+  prefix if;
+
+  description 'Example using just leafs, containers and modules';
+
+  typedef mybits-type {
+    type bits {
+      bit disable-nagle {
+        position 0;
+      }
+      bit auto-sense-speed {
+        position 1;
+      }
+      bit ten-mb-only {
+        position 2;
+      }
+    }
+  }
+
+  container interfaces {
+    description 'Just a simple example of a container.';
+
+    leaf name {
+        type string;
+        mandatory "true";
+        description
+            "Interface name. Example value: GigabitEthernet 0/0/0";
+    }
+
+    leaf mybits {
+       type mybits-type;
+    }
+  }
+}

--- a/tests/examples/with_bits/sample_data.json
+++ b/tests/examples/with_bits/sample_data.json
@@ -1,0 +1,8 @@
+{
+    "interfaces": {
+        "interfaces": {
+            "name": "Nice",
+            "mybits": "disable-nagle ten-mb-only"
+        }
+    }
+}

--- a/tests/test_model_structure.py
+++ b/tests/test_model_structure.py
@@ -197,6 +197,12 @@ def reset_optparse():
             [],
             id="decimal64",
         ),
+        param(
+            "examples/with_bits/interfaces.yang",
+            "examples/with_bits/expected.py",
+            [],
+            id="bits",
+        ),
     ],
 )
 def test_model(input_dir: str, expected_file: str, args: List[str], tmp_path: Path):


### PR DESCRIPTION
This implementation can not handle default values as `pyang` returns them in a list. However, it is a quick win by using a string with regex. More improvements need to be done and can be discussed in #32 